### PR TITLE
Describtion on how to install on Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ sudo pacman -S npm nodejs ffmpeg
 ```
 Nautilus integration (optional):
 ```
-sudo pacman -S python-nautilus 
+sudo pacman -S python-nautilus python-gobject2 python-gobject
 ```
 
 ## Install npm dependencies

--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ Nautilus integration (optional):
 sudo dnf install nautilus-python pygobject3 python3-gobject
 ```
 
+### Arch Linux
+```
+sudo pacman -S npm nodejs ffmpeg
+```
+Nautilus integration (optional):
+```
+sudo pacman -S install python-nautilus 
+```
+
 ## Install npm dependencies
 **Before using extension** you also **must** install some additional npm packages.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ sudo pacman -S npm nodejs ffmpeg
 ```
 Nautilus integration (optional):
 ```
-sudo pacman -S install python-nautilus 
+sudo pacman -S python-nautilus 
 ```
 
 ## Install npm dependencies


### PR DESCRIPTION
Addon and nautilus intergration both work. However I'm not fully sure on the dependencies. `python-gobject` is dependency of `python-nautilus` and thus doesn't need to be installed manually, but `pygobject-devel` was already installed on my system.